### PR TITLE
Pin homesick gem to 0.7.0 release.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,6 @@
 maintainer       "Fletcher Nichol"
 maintainer_email "fnichol@nichol.ca"
+name             "homesick"
 license          "Apache 2.0"
 description      "Installs/Configures homesick"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
-gem_package 'homesick'
+gem_package 'homesick' do
+  version '0.7.0'
+end


### PR DESCRIPTION
This commit pins the homesick gem to the release that was working
appropriately with 0.3.x of the cookbook. Homesick was recently
upgraded to 0.8.0 breaking the cookbook.
